### PR TITLE
fixes #1

### DIFF
--- a/kakoune/.config/kak/kakrc
+++ b/kakoune/.config/kak/kakrc
@@ -33,11 +33,11 @@
 # ╰───────────────────────────────────────────────────────────╯
 # > Alias for sourcing files relative to '.config/kak/'.
 def load -params 1 %{ source "%val{config}/%arg{1}" }
-# > Loads setup module.
-load "rc/setup.kak"
 # > Set to true for auto-sourcing all '.kak' files inside the
 #   'rc/' folder.
-set global autoloadrc false
+decl bool autoloadrc false
+# > Loads setup module.
+load "rc/setup.kak"
 
 # ╭───────────────────────────────────────────────────────────╮
 # │ @ Oyster                                                  │

--- a/kakoune/.config/kak/rc/setup.kak
+++ b/kakoune/.config/kak/rc/setup.kak
@@ -5,7 +5,6 @@
 # ┆ # set global autoloadrc true                              ┆
 # ┆   : will find .kak files under rc/ and source them.       ┆
 # ╰───────────────────────────────────────────────────────────╯
-decl bool autoloadrc false
 eval %sh{
   if [[ "$kak_opt_autoloadrc" == "true" ]]; then
     find "$kak_config/rc" -type f | while read -r file; do


### PR DESCRIPTION
Changes declaration to happen on [kakrc](https://github.com/solmateus/.dotfiles/blob/main/kakoune/.config/kak/kakrc) and the order of operations. Removes declaration on [rc/setup.kak](https://github.com/solmateus/.dotfiles/blob/main/kakoune/.config/kak/rc/setup.kak).